### PR TITLE
Hide ratings until 4 ratings are reached

### DIFF
--- a/app/controllers/top_lists_controller.rb
+++ b/app/controllers/top_lists_controller.rb
@@ -27,6 +27,7 @@ class TopListsController < ApplicationController
       {
         name: category[:name],
         recipes: Recipe.tagged_with(category[:tag])
+                      .where("ratings_count >= ?", Rateable::MIN_RATINGS_FOR_DISPLAY)
                       .order(average_rating: :desc, ratings_count: :desc)
                       .limit(10)
       }

--- a/app/frontend/components/RatingControl.vue
+++ b/app/frontend/components/RatingControl.vue
@@ -49,6 +49,7 @@ const props = defineProps({
   rateableId: { type: Number, required: true },
   initialAverage: { type: Number, default: 0 },
   initialCount: { type: Number, default: 0 },
+  minRatings: { type: Number, default: 1 },
   userRating: { type: Number, default: null }
 })
 
@@ -63,12 +64,16 @@ const loading = ref(false)
 
 const canRate = computed(() => isAuthenticated.value)
 
+const hasEnoughRatings = computed(() => count.value >= props.minRatings)
+
 const displayAverage = computed(() => {
+  if (!hasEnoughRatings.value) return '–'
   return Number(average.value).toFixed(1).replace('.', ',')
 })
 
 const countLabel = computed(() => {
   if (count.value === 0) return 'Keine Bewertungen'
+  if (!hasEnoughRatings.value) return `${count.value} von ${props.minRatings} Bewertungen`
   return `${count.value} Bewertung${count.value !== 1 ? 'en' : ''}`
 })
 
@@ -82,6 +87,7 @@ const getColorForScore = (score) => {
 }
 
 const badgeColorClass = computed(() => {
+  if (!hasEnoughRatings.value) return 'bg-gray-400'
   const score = average.value
   if (score === 0) return 'bg-gray-400'
   if (score < 4) return 'bg-red-600'

--- a/app/models/concerns/rateable.rb
+++ b/app/models/concerns/rateable.rb
@@ -1,13 +1,19 @@
 module Rateable
   extend ActiveSupport::Concern
 
+  MIN_RATINGS_FOR_DISPLAY = 4
+
   included do
     has_many :ratings, as: :rateable, dependent: :destroy
   end
 
+  def show_rating?
+    ratings_count >= MIN_RATINGS_FOR_DISPLAY
+  end
+
   def update_rating_cache!
-    current_avg = ratings.average(:score).to_f
     current_count = ratings.count
+    current_avg = current_count >= MIN_RATINGS_FOR_DISPLAY ? ratings.average(:score).to_f : 0.0
 
     update_columns(
       average_rating: current_avg,

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -148,10 +148,15 @@
                     </div>
                  </div>
                  <div class="flex flex-col items-center gap-1">
-                   <div class="<%= rating_badge_class(recipe.average_rating) %> px-2 py-1 md:px-3 md:py-2 md:text-lg rounded text-sm font-bold whitespace-nowrap min-w-[3rem] md:min-w-[4rem] text-center">
-                      <%= number_with_precision(recipe.average_rating, precision: 1, separator: ",") %>
-                   </div>
-                   <span class="text-[10px] text-gray-400 font-normal">(<%= recipe.ratings_count %>)</span>
+                   <% if recipe.show_rating? %>
+                     <div class="<%= rating_badge_class(recipe.average_rating) %> px-2 py-1 md:px-3 md:py-2 md:text-lg rounded text-sm font-bold whitespace-nowrap min-w-[3rem] md:min-w-[4rem] text-center">
+                       <%= number_with_precision(recipe.average_rating, precision: 1, separator: ",") %>
+                     </div>
+                     <span class="text-[10px] text-gray-400 font-normal">(<%= recipe.ratings_count %>)</span>
+                   <% else %>
+                     <div class="bg-gray-400 px-2 py-1 md:px-3 md:py-2 md:text-lg rounded text-sm font-bold whitespace-nowrap min-w-[3rem] md:min-w-[4rem] text-center text-white">–</div>
+                     <span class="text-[10px] text-gray-400 font-normal">(<%= recipe.ratings_count %>/4)</span>
+                   <% end %>
                  </div>
               </div>
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -40,9 +40,10 @@
           :rateable-id="<%= @recipe.id %>"
           :initial-average="<%= @recipe.average_rating || 0 %>"
           :initial-count="<%= @recipe.ratings_count || 0 %>"
+          :min-ratings="<%= Rateable::MIN_RATINGS_FOR_DISPLAY %>"
           :user-rating="<%= (Current.user && @recipe.ratings.find_by(user: Current.user)&.score) || 'null' %>"
         ></rating-control>
-        <% if @recipe.ratings_count.to_i > 0 %>
+        <% if @recipe.show_rating? %>
           <%= link_to bewertungen_recipe_path(@recipe), class: "text-sm text-cs-dark-red hover:underline mt-1 inline-block" do %>
             <i class="fas fa-chart-bar mr-1"></i> Alle Bewertungen ansehen
           <% end %>

--- a/lib/tasks/ratings.rake
+++ b/lib/tasks/ratings.rake
@@ -1,0 +1,19 @@
+namespace :ratings do
+  desc "Recalculate rating cache for all recipes (sets average_rating to 0 for recipes below the minimum ratings threshold)"
+  task recalculate_cache: :environment do
+    threshold = Rateable::MIN_RATINGS_FOR_DISPLAY
+    scope = Recipe.unscoped.where("ratings_count > 0 AND ratings_count < ?", threshold)
+    count = scope.count
+
+    puts "Recalculating rating cache..."
+    puts "Recipes with ratings below threshold (< #{threshold}): #{count}"
+
+    scope.find_each do |recipe|
+      recipe.update_rating_cache!
+      print "."
+    end
+
+    puts ""
+    puts "Done."
+  end
+end

--- a/spec/helpers/structured_data_helper_spec.rb
+++ b/spec/helpers/structured_data_helper_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe StructuredDataHelper, type: :helper do
     end
 
     it "includes aggregate rating if ratings exist" do
-      create(:rating, rateable: recipe, score: 5)
+      4.times { create(:rating, rateable: recipe, score: 5) }
       recipe.reload # reload to update counter cache or calculation
 
       output = helper.recipe_structured_data(recipe)

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -119,31 +119,55 @@ RSpec.describe Rating, type: :model do
     end
 
     describe "rating cache updates" do
-      it "calculates correct average with one rating" do
-        Rating.create!(user: user, rateable: recipe, score: 8)
-
-        recipe.reload
-        expect(recipe.average_rating).to eq(8.0)
-        expect(recipe.ratings_count).to eq(1)
-      end
-
-      it "calculates correct average with multiple ratings" do
+      it "returns 0.0 average when fewer than #{Rateable::MIN_RATINGS_FOR_DISPLAY} ratings exist" do
         user2 = create(:user)
         user3 = create(:user)
-
         Rating.create!(user: user, rateable: recipe, score: 8)
         Rating.create!(user: user2, rateable: recipe, score: 6)
         Rating.create!(user: user3, rateable: recipe, score: 10)
 
         recipe.reload
-        expect(recipe.average_rating).to eq(8.0)
+        expect(recipe.average_rating).to eq(0.0)
         expect(recipe.ratings_count).to eq(3)
+      end
+
+      it "calculates correct average with minimum ratings threshold" do
+        user2 = create(:user)
+        user3 = create(:user)
+        user4 = create(:user)
+        Rating.create!(user: user, rateable: recipe, score: 8)
+        Rating.create!(user: user2, rateable: recipe, score: 8)
+        Rating.create!(user: user3, rateable: recipe, score: 8)
+        Rating.create!(user: user4, rateable: recipe, score: 8)
+
+        recipe.reload
+        expect(recipe.average_rating).to eq(8.0)
+        expect(recipe.ratings_count).to eq(4)
+      end
+
+      it "calculates correct average with multiple ratings" do
+        user2 = create(:user)
+        user3 = create(:user)
+        user4 = create(:user)
+
+        Rating.create!(user: user, rateable: recipe, score: 8)
+        Rating.create!(user: user2, rateable: recipe, score: 6)
+        Rating.create!(user: user3, rateable: recipe, score: 10)
+        Rating.create!(user: user4, rateable: recipe, score: 8)
+
+        recipe.reload
+        expect(recipe.average_rating).to eq(8.0)
+        expect(recipe.ratings_count).to eq(4)
       end
 
       it "updates average when a rating is changed" do
         user2 = create(:user)
-        rating1 = Rating.create!(user: user, rateable: recipe, score: 8)
+        user3 = create(:user)
+        user4 = create(:user)
+        rating1 = Rating.create!(user: user, rateable: recipe, score: 6)
         Rating.create!(user: user2, rateable: recipe, score: 6)
+        Rating.create!(user: user3, rateable: recipe, score: 8)
+        Rating.create!(user: user4, rateable: recipe, score: 8)
 
         recipe.reload
         expect(recipe.average_rating).to eq(7.0)
@@ -152,23 +176,29 @@ RSpec.describe Rating, type: :model do
 
         recipe.reload
         expect(recipe.average_rating).to eq(8.0)
-        expect(recipe.ratings_count).to eq(2)
+        expect(recipe.ratings_count).to eq(4)
       end
 
       it "updates average when a rating is destroyed" do
         user2 = create(:user)
-        rating1 = Rating.create!(user: user, rateable: recipe, score: 8)
-        Rating.create!(user: user2, rateable: recipe, score: 6)
+        user3 = create(:user)
+        user4 = create(:user)
+        user5 = create(:user)
+        rating1 = Rating.create!(user: user, rateable: recipe, score: 3)
+        Rating.create!(user: user2, rateable: recipe, score: 8)
+        Rating.create!(user: user3, rateable: recipe, score: 8)
+        Rating.create!(user: user4, rateable: recipe, score: 8)
+        Rating.create!(user: user5, rateable: recipe, score: 8)
 
         recipe.reload
         expect(recipe.average_rating).to eq(7.0)
-        expect(recipe.ratings_count).to eq(2)
+        expect(recipe.ratings_count).to eq(5)
 
         rating1.destroy
 
         recipe.reload
-        expect(recipe.average_rating).to eq(6.0)
-        expect(recipe.ratings_count).to eq(1)
+        expect(recipe.average_rating).to eq(8.0)
+        expect(recipe.ratings_count).to eq(4)
       end
 
       it "handles removal of all ratings" do

--- a/spec/requests/ratings_spec.rb
+++ b/spec/requests/ratings_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe "Ratings API", type: :request do
       before { sign_in(user) }
 
       it "creates a new rating" do
+        other_user2 = create(:user)
+        other_user3 = create(:user)
+        other_user4 = create(:user)
+        Rating.create!(user: other_user2, rateable: recipe, score: 8)
+        Rating.create!(user: other_user3, rateable: recipe, score: 8)
+        Rating.create!(user: other_user4, rateable: recipe, score: 8)
+
         expect {
           post rate_path, params: { rateable_type: "Recipe", rateable_id: recipe.id, score: 8 }
         }.to change { Rating.count }.by(1)
@@ -18,11 +25,17 @@ RSpec.describe "Ratings API", type: :request do
         expect(json["success"]).to be true
         expect(json["rating"]["score"]).to eq(8)
         expect(json["average"].to_f).to eq(8.0)
-        expect(json["count"]).to eq(1)
+        expect(json["count"]).to eq(4)
       end
 
       it "updates an existing rating" do
+        other_user2 = create(:user)
+        other_user3 = create(:user)
+        other_user4 = create(:user)
         Rating.create!(user: user, rateable: recipe, score: 5)
+        Rating.create!(user: other_user2, rateable: recipe, score: 9)
+        Rating.create!(user: other_user3, rateable: recipe, score: 9)
+        Rating.create!(user: other_user4, rateable: recipe, score: 9)
 
         expect {
           post rate_path, params: { rateable_type: "Recipe", rateable_id: recipe.id, score: 9 }
@@ -33,19 +46,23 @@ RSpec.describe "Ratings API", type: :request do
         expect(json["success"]).to be true
         expect(json["rating"]["score"]).to eq(9)
         expect(json["average"].to_f).to eq(9.0)
-        expect(json["count"]).to eq(1)
+        expect(json["count"]).to eq(4)
       end
 
       it "returns the updated average and count with multiple ratings" do
         other_user = create(:user)
+        user3 = create(:user)
+        user4 = create(:user)
         Rating.create!(user: other_user, rateable: recipe, score: 6)
+        Rating.create!(user: user3, rateable: recipe, score: 6)
+        Rating.create!(user: user4, rateable: recipe, score: 8)
 
         post rate_path, params: { rateable_type: "Recipe", rateable_id: recipe.id, score: 8 }
 
         expect(response).to have_http_status(:success)
         json = JSON.parse(response.body)
-        expect(json["average"].to_f).to eq(7.0) # (6 + 8) / 2
-        expect(json["count"]).to eq(2)
+        expect(json["average"].to_f).to eq(7.0) # (6 + 6 + 8 + 8) / 4
+        expect(json["count"]).to eq(4)
       end
 
       it "accepts valid scores from 1 to 10" do
@@ -108,11 +125,18 @@ RSpec.describe "Ratings API", type: :request do
       end
 
       it "updates the recipe's rating cache" do
+        other_user2 = create(:user)
+        other_user3 = create(:user)
+        other_user4 = create(:user)
+        Rating.create!(user: other_user2, rateable: recipe, score: 7)
+        Rating.create!(user: other_user3, rateable: recipe, score: 7)
+        Rating.create!(user: other_user4, rateable: recipe, score: 7)
+
         post rate_path, params: { rateable_type: "Recipe", rateable_id: recipe.id, score: 7 }
 
         recipe.reload
         expect(recipe.average_rating).to eq(7.0)
-        expect(recipe.ratings_count).to eq(1)
+        expect(recipe.ratings_count).to eq(4)
       end
     end
 
@@ -152,15 +176,21 @@ RSpec.describe "Ratings API", type: :request do
 
       it "updates the average after deletion" do
         other_user = create(:user)
+        user3 = create(:user)
+        user4 = create(:user)
+        user5 = create(:user)
         Rating.create!(user: user, rateable: recipe, score: 8)
         Rating.create!(user: other_user, rateable: recipe, score: 6)
+        Rating.create!(user: user3, rateable: recipe, score: 6)
+        Rating.create!(user: user4, rateable: recipe, score: 6)
+        Rating.create!(user: user5, rateable: recipe, score: 6)
 
         delete rate_path, params: { rateable_type: "Recipe", rateable_id: recipe.id }
 
         expect(response).to have_http_status(:success)
         json = JSON.parse(response.body)
         expect(json["average"].to_f).to eq(6.0)
-        expect(json["count"]).to eq(1)
+        expect(json["count"]).to eq(4)
       end
 
       it "returns 404 when rating does not exist" do

--- a/spec/requests/top_lists_spec.rb
+++ b/spec/requests/top_lists_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "TopLists", type: :request do
     context "when there are tagged recipes" do
       let!(:gin_recipe_1) { create(:recipe, average_rating: 9.5, ratings_count: 10) }
       let!(:gin_recipe_2) { create(:recipe, average_rating: 8.5, ratings_count: 5) }
-      let!(:gin_recipe_3) { create(:recipe, average_rating: 7.0, ratings_count: 3) }
+      let!(:gin_recipe_3) { create(:recipe, average_rating: 7.0, ratings_count: 4) }
       let!(:rum_recipe) { create(:recipe, average_rating: 9.0, ratings_count: 8) }
 
       before do


### PR DESCRIPTION
Recipes with fewer than 4 ratings store 0 in the average_rating cache so they are naturally excluded from rating filters and sort-by-rating. The index shows a gray "–" badge with progress (X/4) for all unqualified recipes. Adds a rake task to backfill existing recipes.