### PR TITLE
Add GFM table support to markdown renderer

### DIFF
--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -244,6 +244,10 @@ nav.pagy a[role="separator"] {
 .prose-cs strong { @apply font-bold; }
 .prose-cs em { @apply italic; }
 .prose-cs hr { @apply border-0 border-t border-gray-300 my-6 mx-8; }
+.prose-cs table { @apply w-full border-collapse mb-4 text-sm; }
+.prose-cs th { @apply border border-gray-300 bg-gray-50 px-3 py-2 text-left font-semibold; }
+.prose-cs td { @apply border border-gray-300 px-3 py-2 align-top; }
+.prose-cs tbody tr:nth-child(even) td { @apply bg-gray-50; }
 
 /* User Ranks */
 .rank-0-color { color: #9A9A1E; }

--- a/app/frontend/lib/markdownPreview.js
+++ b/app/frontend/lib/markdownPreview.js
@@ -41,6 +41,9 @@ function preprocessShortcodes(text) {
     return key
   })
 
+  // Strip leading spaces from table row lines so marked recognises them as tables.
+  t = t.replace(/^ +(\|)/gm, '$1')
+
   // Internal wikilinks — client-side preview uses slug/id as label when no custom text;
   // the server-side renderer does DB lookups for actual titles.
   t = t.replace(WIKILINK, (_, type, ref, label) => {
@@ -102,7 +105,7 @@ const ALLOWED_TAGS = [
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
   'table', 'thead', 'tbody', 'tr', 'th', 'td',
 ]
-const ALLOWED_ATTR = ['href', 'src', 'alt', 'title', 'class', 'rel', 'target']
+const ALLOWED_ATTR = ['href', 'src', 'alt', 'title', 'class', 'rel', 'target', 'align']
 
 export function renderMarkdown(text, smileys = SMILEYS) {
   if (!text) return ''

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -6,7 +6,7 @@ module MarkdownHelper
   ].freeze
 
   # Rails sanitize() takes a flat list of allowed attribute names (not per-tag)
-  MARKDOWN_ALLOWED_ATTRIBUTES = %w[href src alt title class rel target].freeze
+  MARKDOWN_ALLOWED_ATTRIBUTES = %w[href src alt title class rel target align].freeze
 
   # Wikilink pattern: [[type:ref]] or [[type:ref|Custom Text]]
   WIKILINK_PATTERN = /\[\[([a-z]+):([a-zA-Z0-9\-]+)(?:\|([^\]]+))?\]\]/
@@ -55,6 +55,10 @@ module MarkdownHelper
       idx += 1
       key
     end
+
+    # Strip leading spaces from table row lines so Redcarpet recognises them as tables.
+    # Indented pipes (e.g. "  | col |") are not detected as table rows.
+    t.gsub!(/^ +(\|)/, '\\1')
 
     # Wikilinks: [[recipe:slug]], [[recipe:slug|Custom Text]],
     #            [[thread:slug]], [[thread:slug|Custom Text]],

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -103,6 +103,22 @@ RSpec.describe MarkdownHelper, type: :helper do
       expect(result).to include("This is a quote")
     end
 
+    it "renders a basic table" do
+      text = "| A | B |\n|---|---|\n| 1 | 2 |"
+      result = helper.render_markdown(text)
+      expect(result).to include("<table>")
+      expect(result).to include("<th>A</th>")
+      expect(result).to include("<td>1</td>")
+    end
+
+    it "renders a table with leading indentation" do
+      text = "  | A | B |\n  |---|---|\n  | 1 | 2 |"
+      result = helper.render_markdown(text)
+      expect(result).to include("<table>")
+      expect(result).to include("<th>A</th>")
+      expect(result).to include("<td>1</td>")
+    end
+
     it "handles mixed formatting" do
       text = "# Title\n\nThis is **bold** and *italic* with a [link](https://example.com)"
       result = helper.render_markdown(text)


### PR DESCRIPTION
- Enable table tags in both sanitizers (already had tables: true in Redcarpet)
- Add align attribute to allowed attributes for table column alignment
- Strip leading spaces from table row lines before parsing so indented content (e.g. pasted from HAML) is recognised as a table by Redcarpet
- Add prose-cs table styles since @tailwindcss/typography is not installed
- Add specs for basic table and indented table rendering