### PR TITLE
Add admin gallery view for bulk high-quality image toggling

### DIFF
--- a/app/controllers/admin/high_quality_recipe_images_controller.rb
+++ b/app/controllers/admin/high_quality_recipe_images_controller.rb
@@ -5,13 +5,19 @@ module Admin
     def create
       recipe_image = RecipeImage.find(params[:recipe_image_id])
       recipe_image.update!(high_quality: true)
-      redirect_to admin_recipe_image_path(recipe_image), notice: "Bild als hochwertig markiert."
+      respond_to do |format|
+        format.json { render json: { high_quality: true } }
+        format.html { redirect_to admin_recipe_image_path(recipe_image), notice: "Bild als hochwertig markiert." }
+      end
     end
 
     def destroy
       recipe_image = RecipeImage.find(params[:id])
       recipe_image.update!(high_quality: false)
-      redirect_to admin_recipe_image_path(recipe_image), notice: "Hochwertig-Markierung entfernt."
+      respond_to do |format|
+        format.json { render json: { high_quality: false } }
+        format.html { redirect_to admin_recipe_image_path(recipe_image), notice: "Hochwertig-Markierung entfernt." }
+      end
     end
 
     private

--- a/app/controllers/admin/recipe_images_controller.rb
+++ b/app/controllers/admin/recipe_images_controller.rb
@@ -62,6 +62,16 @@ module Admin
       render json: { count: RecipeImage.pending.count }
     end
 
+    def gallery
+      @recipe_images = RecipeImage.includes(:recipe, :user)
+                                   .approved.not_soft_deleted
+                                   .then { |q| filter_by_recipe_name(q) }
+                                   .then { |q| filter_by_high_quality(q) }
+                                   .high_quality_first
+                                   .recent
+      @pagy, @recipe_images = pagy(@recipe_images, limit: 60)
+    end
+
     private
 
     def require_image_moderator!
@@ -77,6 +87,14 @@ module Admin
     def filter_by_recipe_name(query)
       return query if params[:q].blank?
       query.joins(:recipe).where("recipes.title LIKE ?", "%#{params[:q]}%")
+    end
+
+    def filter_by_high_quality(query)
+      case params[:hq]
+      when "yes" then query.where(high_quality: true)
+      when "no"  then query.where(high_quality: false)
+      else query
+      end
     end
 
     def filter_by_state(query)

--- a/app/frontend/components/AdminHighQualityGallery.vue
+++ b/app/frontend/components/AdminHighQualityGallery.vue
@@ -1,0 +1,92 @@
+<template>
+  <div>
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+      <div
+        v-for="image in images"
+        :key="image.id"
+        class="group relative aspect-square overflow-hidden rounded-xl shadow-sm hover:shadow-lg transition-all duration-300"
+      >
+        <img
+          :src="image.thumbnailUrl"
+          :alt="image.recipeTitle"
+          class="object-cover w-full h-full transition-transform duration-500 group-hover:scale-[1.05]"
+          loading="lazy"
+        />
+        <div class="absolute inset-0 bg-gradient-to-t from-black/65 via-black/5 to-transparent"></div>
+        <div class="absolute bottom-0 left-0 right-0 p-2.5">
+          <p class="font-display font-semibold text-white text-[13px] leading-tight line-clamp-2 drop-shadow">{{ image.recipeTitle }}</p>
+        </div>
+
+        <button
+          @click="toggleHQ(image)"
+          :disabled="image.loading"
+          class="absolute top-2 right-2 rounded-full p-1.5 shadow transition-all"
+          :class="image.highQuality
+            ? 'bg-cs-gold-500 hover:bg-cs-gold-600'
+            : 'bg-black/40 hover:bg-black/60'"
+          :title="image.highQuality ? 'Hochwertig-Markierung entfernen' : 'Als hochwertig markieren'"
+        >
+          <i
+            class="text-white text-sm leading-none"
+            :class="[
+              image.highQuality ? 'fa-solid fa-star' : 'fa-regular fa-star',
+              image.loading ? 'animate-pulse' : ''
+            ]"
+          ></i>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const images = ref([])
+
+onMounted(() => {
+  if (window.adminGalleryImages) {
+    images.value = window.adminGalleryImages.map(img => ({ ...img, loading: false }))
+  }
+})
+
+const csrfToken = () => document.querySelector('meta[name="csrf-token"]').content
+
+const toggleHQ = async (image) => {
+  if (image.loading) return
+  image.loading = true
+
+  try {
+    let response
+    if (image.highQuality) {
+      response = await fetch(`/admin/high_quality_recipe_images/${image.id}`, {
+        method: 'DELETE',
+        headers: {
+          'Accept': 'application/json',
+          'X-CSRF-Token': csrfToken()
+        }
+      })
+    } else {
+      response = await fetch('/admin/high_quality_recipe_images', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'X-CSRF-Token': csrfToken()
+        },
+        body: JSON.stringify({ recipe_image_id: image.id })
+      })
+    }
+
+    if (response.ok) {
+      image.highQuality = !image.highQuality
+    } else {
+      console.error('Failed to toggle high quality', response.status)
+    }
+  } catch (e) {
+    console.error(e)
+  } finally {
+    image.loading = false
+  }
+}
+</script>

--- a/app/frontend/registry/components.js
+++ b/app/frontend/registry/components.js
@@ -34,6 +34,7 @@ const components = {
   UserBadge: () => import('../components/UserBadge.vue'),
   SiteNav: () => import('../components/SiteNav.vue'),
   RecipeFilters: () => import('../components/RecipeFilters.vue'),
+  AdminHighQualityGallery: () => import('../components/AdminHighQualityGallery.vue'),
   // Add future components here:
   // CocktailCard: () => import('../components/CocktailCard.vue'),
 }

--- a/app/views/admin/recipe_images/gallery.html.erb
+++ b/app/views/admin/recipe_images/gallery.html.erb
@@ -1,0 +1,61 @@
+<div class="mb-8 flex items-center justify-between">
+  <div>
+    <h1 class="text-3xl font-bold text-cs-ink-800">Bildergalerie</h1>
+    <p class="text-sm text-cs-ink-500 mt-1">Gesamt: <strong><%= @pagy.count %></strong> Bilder</p>
+  </div>
+  <%= link_to "← Listenansicht", admin_recipe_images_path, class: "btn btn-outline" %>
+</div>
+
+<!-- Filters -->
+<div class="bg-white rounded-lg shadow border border-cs-ink-200 p-4 mb-6">
+  <%= form_with url: gallery_admin_recipe_images_path, method: :get, class: "flex flex-wrap gap-3 items-end" do |f| %>
+    <div class="flex-1 min-w-[200px]">
+      <%= f.label :q, "Rezept suchen", class: "label-field" %>
+      <%= f.text_field :q, value: params[:q], placeholder: "Rezeptname...", class: "input-field" %>
+    </div>
+    <div class="min-w-[180px]">
+      <%= f.label :hq, "Qualität", class: "label-field" %>
+      <%= f.select :hq,
+            [["Alle", ""], ["Nur hochwertig", "yes"], ["Nicht hochwertig", "no"]],
+            { selected: params[:hq] },
+            class: "input-field" %>
+    </div>
+    <%= f.submit "Filtern", class: "btn btn-primary" %>
+    <% if params[:q].present? || params[:hq].present? %>
+      <%= link_to "Zurücksetzen", gallery_admin_recipe_images_path, class: "btn btn-outline" %>
+    <% end %>
+  <% end %>
+</div>
+
+<!-- Pagination top -->
+<% if @pagy.pages > 1 %>
+  <div class="mb-6">
+    <%== @pagy.series_nav %>
+  </div>
+<% end %>
+
+<% if @recipe_images.any? %>
+  <admin-high-quality-gallery id="hq-gallery"></admin-high-quality-gallery>
+
+  <!-- Pagination bottom -->
+  <% if @pagy.pages > 1 %>
+    <div class="mt-6">
+      <%== @pagy.series_nav %>
+    </div>
+  <% end %>
+<% else %>
+  <div class="bg-white rounded-lg shadow border border-cs-ink-200 p-12 text-center">
+    <i class="fa-solid fa-images text-6xl text-cs-ink-300 mb-4"></i>
+    <h3 class="text-xl font-semibold text-cs-ink-700 mb-2">Keine Bilder gefunden</h3>
+    <p class="text-cs-ink-600">Es gibt keine genehmigten Bilder für diese Filtereinstellungen.</p>
+  </div>
+<% end %>
+
+<script>
+  window.adminGalleryImages = <%= raw @recipe_images.select { |i| i.image.attached? }.map { |i| {
+    id: i.id,
+    thumbnailUrl: url_for(i.image.variant(:medium)),
+    recipeTitle: i.recipe&.title || "(Rezept gelöscht)",
+    highQuality: i.high_quality
+  } }.to_json %>;
+</script>

--- a/app/views/admin/recipe_images/index.html.erb
+++ b/app/views/admin/recipe_images/index.html.erb
@@ -1,7 +1,12 @@
 <div class="mb-8 flex items-center justify-between">
   <h1 class="text-3xl font-bold text-cs-ink-800">Bilder</h1>
-  <div class="text-sm text-cs-ink-600">
-    Gesamt: <strong><%= @pagy.count %></strong> Bilder
+  <div class="flex items-center gap-4">
+    <div class="text-sm text-cs-ink-600">
+      Gesamt: <strong><%= @pagy.count %></strong> Bilder
+    </div>
+    <%= link_to gallery_admin_recipe_images_path, class: "btn btn-outline" do %>
+      <i class="fa-solid fa-grip mr-1"></i> Galerie-Ansicht
+    <% end %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       end
       collection do
         get :count
+        get :gallery
       end
     end
   end


### PR DESCRIPTION
Adds a gallery page at /admin/recipe_images/gallery showing approved images in a responsive grid. Each card has an inline star toggle (Vue 3 + fetch) to mark/unmark high quality without a page reload. Filters for recipe name and HQ status are server-side GET forms.